### PR TITLE
Fix broken navbar: stop double-minifying Tailwind CSS in production (…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Run upgrade CLI integration test ⬆️
         run: bash test/integration_upgrade_cli.sh
+
+      - name: Run CSS minify integration test 🎨
+        run: bash test/integration_css_minify.sh

--- a/Gemfile
+++ b/Gemfile
@@ -40,10 +40,10 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.9'
+    gem 'al_folio_core', '= 1.0.10'
     gem 'al_icons', '= 1.0.0'
     gem 'al_folio_cv', '= 1.0.0'
-    gem 'al_folio_distill', '= 1.0.1'
+    gem 'al_folio_distill', '= 1.0.2'
     gem 'al_folio_upgrade', '= 1.0.3'
     gem 'al_folio_bootstrap_compat', '= 1.0.0'
     gem 'al_cookie', '= 1.0.0'
@@ -53,7 +53,7 @@ group :al_folio_plugins do
     gem 'al_ext_posts', '= 1.0.1'
     gem 'al_img_tools', '= 1.0.2'
     gem 'al_search', '= 1.0.2'
-    gem 'al_charts', '= 1.0.0'
+    gem 'al_charts', '= 1.0.1'
     gem 'al_math', '= 1.0.1'
     gem 'al_comments', '= 1.0.0'
     gem 'al_newsletter', '= 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     al_analytics (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_charts (1.0.0)
+    al_charts (1.0.1)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_citations (1.0.1)
@@ -47,13 +47,13 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.9)
+    al_folio_core (1.0.10)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_cv (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_distill (1.0.1)
+    al_folio_distill (1.0.2)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_upgrade (1.0.3)
@@ -241,7 +241,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.19.7)
     json-minify (0.0.3)
       json (> 0)
     kramdown (2.5.2)
@@ -346,15 +346,15 @@ PLATFORMS
 
 DEPENDENCIES
   al_analytics (= 1.0.0)
-  al_charts (= 1.0.0)
+  al_charts (= 1.0.1)
   al_citations (= 1.0.1)
   al_comments (= 1.0.0)
   al_cookie (= 1.0.0)
   al_ext_posts (= 1.0.1)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.9)
+  al_folio_core (= 1.0.10)
   al_folio_cv (= 1.0.0)
-  al_folio_distill (= 1.0.1)
+  al_folio_distill (= 1.0.2)
   al_folio_upgrade (= 1.0.3)
   al_icons (= 1.0.0)
   al_img_tools (= 1.0.2)
@@ -391,15 +391,15 @@ CHECKSUMS
   activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   al_analytics (1.0.0) sha256=5538a59212ad68c21f54f757a1286422182dbdb18093959da876b66273b0ebcb
-  al_charts (1.0.0) sha256=7f779cae01e9aa28ed863dc06347ae2632cc21417ff74415667bc21556220d95
+  al_charts (1.0.1) sha256=ce26374c2b1159ae0d65dc7999730be700a9ee486002ae14cb480eef70580885
   al_citations (1.0.1) sha256=308cfd4cd73c8dc6d24c0214f424b61606b3a393bdb899394fce80dd647cba59
   al_comments (1.0.0) sha256=1da87a29b55e4d9fd62d380200af9671f10ae4a84e3259828588498d8f3210e5
   al_cookie (1.0.0) sha256=0b36310f84c88e758fb18f2217e8fca8a282b8bd7f5ee9793c6d38ca0cc97348
   al_ext_posts (1.0.1) sha256=432730bcf032e9da0277beded65511a6e836d4888bda19c9e0f58f9bc6cd2a1d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.9) sha256=2f81477fb1e12d79dcd927815c9f22f3392157917a89a936308a6f22645e373a
+  al_folio_core (1.0.10) sha256=13620d361f43e3bc8842f3655025e9688a6e494abb85770f085377bf60cdd678
   al_folio_cv (1.0.0) sha256=aa54c6efb38f46c5da09e09b82b4b050b5ce3b384f808922dc4fd665e10a840e
-  al_folio_distill (1.0.1) sha256=f8ca859acdec0673ccd8b5314331af2bb0d1373461e22978f87dff68445550e9
+  al_folio_distill (1.0.2) sha256=14075b8654a85f76e5e1d8adf8e6c7abcf7b618a4f83a622fa4d5054cd64c709
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709
   al_icons (1.0.0) sha256=7a7b6428d18e77b039aa1ae765a3faed0ae27cb646a08c1009b145c31ca5ef2d
   al_img_tools (1.0.2) sha256=1b86e860984d2f714e5a7d715e79722f280e90cc6739375a9119fc9dcb5bb8d6
@@ -476,7 +476,7 @@ CHECKSUMS
   jekyll-twitter-plugin (2.1.0) sha256=d25ee86813705244dcec3163d9a110a1c0216e157dcf6cf88ab57cf389887acd
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
   jemoji (0.13.0) sha256=5d4c3e8e2cbbb2b73997c31294f6f70c94e4d4fade039373e86835bcf5529e7c
-  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
   json-minify (0.0.3) sha256=fd38ef93867332c2340aaf1b57335782ab5958fe6fb3ca7a8aba1469f0bf08ae
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729

--- a/_config.yml
+++ b/_config.yml
@@ -303,7 +303,13 @@ sass:
 
 jekyll-minifier:
   compress_javascript: false # set to false since we are using terser as the js minifier
-  exclude: ["robots.txt", "assets/js/search/*.js"]
+  # CSS is already minified upstream (Tailwind build ships tailwind.css; main.scss is compiled
+  # with sass `style: compressed`). Re-minifying via cssminify2 mangles Tailwind v4 spacing
+  # tokens inside calc(), turning `var(--spacing)` into the invalid `var( -  - spacing)` and
+  # breaking every spacing/positioning utility (e.g. .fixed-top -> broken navbar). Disable it.
+  compress_css: false
+  # JS minification is delegated to jekyll-terser (compress_javascript above is false).
+  exclude: ["robots.txt"]
 
 # -----------------------------------------------------------------------------
 # Terser

--- a/_posts/2023-05-12-custom-blockquotes.md
+++ b/_posts/2023-05-12-custom-blockquotes.md
@@ -11,7 +11,7 @@ related_posts: true
 
 This post shows how to add custom styles for blockquotes. Based on [jekyll-gitbook](https://github.com/sighingnow/jekyll-gitbook) implementation.
 
-We decided to support the same custom blockquotes as in [jekyll-gitbook](https://sighingnow.github.io/jekyll-gitbook/jekyll/2022-06-30-tips_warnings_dangers.html), which are also found in a lot of other sites' styles. The styles definitions can be found on the [\_sass/\_typograms.scss](https://github.com/alshedivat/al-folio/blob/main/_sass/_typograms.scss) file, more specifically:
+We decided to support the same custom blockquotes as in [jekyll-gitbook](https://sighingnow.github.io/jekyll-gitbook/jekyll/2022-06-30-tips_warnings_dangers.html), which are also found in a lot of other sites' styles. The styles definitions can be found on the [\_sass/\_typograms.scss](https://github.com/al-org-dev/al-folio-core/blob/main/_sass/_typograms.scss) file, more specifically:
 
 ```scss
 /* Tips, warnings, and dangers */

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -18,5 +18,10 @@ module.exports = {
     "font-weight-bold",
     "font-weight-medium",
     "font-weight-lighter",
+    // medium-zoom injects these at runtime, so they never appear in the static
+    // HTML PurgeCSS scans; without them the zoom overlay's z-index rule is purged
+    // and page chrome (scroll-progress bar, ToC) bleeds through a zoomed image.
+    "medium-zoom-overlay",
+    "medium-zoom-image--opened",
   ],
 };

--- a/test/integration_css_minify.sh
+++ b/test/integration_css_minify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression guard for the production CSS pipeline.
+#
+# In production (JEKYLL_ENV=production) the build runs jekyll-minifier. Its CSS
+# compressor (cssminify2) mangles Tailwind v4 spacing tokens inside calc(),
+# rewriting `calc(var(--spacing)*N)` to the invalid `calc(var( -  - spacing)*N)`.
+# That breaks every spacing/positioning utility (e.g. `.fixed-top` -> the navbar
+# is no longer pinned). The starter disables redundant CSS minification
+# (`jekyll-minifier.compress_css: false` in _config.yml) because tailwind.css and
+# the Sass-compiled main.css are already minified upstream.
+#
+# This bug only surfaces in PRODUCTION builds, so the other integration tests
+# (dev-mode builds) and the visual-regression workflow (serves in dev mode)
+# never caught it. This test builds in production mode on purpose.
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+site="${tmp_dir}/site"
+override_file="${tmp_dir}/im-off.yml"
+
+# Disable ImageMagick responsive-image generation: it is unrelated to CSS and is
+# by far the slowest build step. CSS output is identical with it on or off.
+cat >"${override_file}" <<'YAML'
+imagemagick:
+  enabled: false
+YAML
+
+JEKYLL_ENV=production bundle exec jekyll build \
+  --config "_config.yml,${override_file}" -d "${site}" >/dev/null
+
+tailwind_css="${site}/assets/css/tailwind.css"
+main_css="${site}/assets/css/main.css"
+
+[ -f "${tailwind_css}" ] || {
+  echo "tailwind.css missing from production build" >&2
+  exit 1
+}
+
+# The smoking gun: a corrupted custom-property reference anywhere in the CSS.
+if grep -qF 'var( -  - ' "${tailwind_css}" "${main_css}"; then
+  echo "corrupted CSS variable reference 'var( -  - ...)' found in production CSS" >&2
+  echo "  -> jekyll-minifier is re-minifying already-minified CSS; keep compress_css: false" >&2
+  exit 1
+fi
+
+# Positive assertions: Tailwind's spacing scale and the fixed navbar survive.
+grep -qF 'var(--spacing)' "${tailwind_css}" || {
+  echo "expected intact 'var(--spacing)' tokens in tailwind.css" >&2
+  exit 1
+}
+if ! grep -oE '\.fixed-top[^{]*\{[^}]*\}' "${tailwind_css}" | grep -q 'position:fixed'; then
+  echo ".fixed-top rule is missing or malformed in production tailwind.css" >&2
+  exit 1
+fi
+
+# main.css carries the navbar's visual theming (hamburger bars, toggles); it must
+# be non-empty (a Sass compile failure would silently emit an empty file).
+main_bytes="$(wc -c <"${main_css}" 2>/dev/null || echo 0)"
+if [ "${main_bytes}" -lt 1000 ]; then
+  echo "main.css is empty/too small (${main_bytes} bytes) in production build" >&2
+  exit 1
+fi
+
+echo "css minify integration checks passed"


### PR DESCRIPTION
…#3634)

## Summary

Fixes the broken navigation bar on the live demo
(https://alshedivat.github.io/al-folio/) introduced by the v1.0 upgrade (#2968), plus two related production/deploy-only issues found while auditing for the same class of bug.

## Root cause of the navbar break

The v1.0 upgrade made the site **Tailwind-first**. The deploy builds with `JEKYLL_ENV=production`, which activates **jekyll-minifier**. Its CSS compressor (`cssminify2`) mangles Tailwind v4 spacing tokens **inside `calc()`**:

```
calc(var(--spacing)*0)   ->   calc(var( -  - spacing)*0)   // invalid
```

`cssminify2` treats the `--` inside `calc(var(--…))` as minus operators and inserts spaces, producing an invalid custom-property name. This silently breaks **every** spacing/positioning utility — most visibly `.fixed-top`, so the fixed navbar is no longer pinned (`top/left/right` drop out) and renders incorrectly. On the live site this affects 33 `var(--spacing)` references in `tailwind.css`.

It only manifests in **production**: a local `bundle exec jekyll serve` is development mode (minifier off), and the `visual-regression` workflow also serves in dev mode — so neither caught it.

### Why this fix

`tailwind.css` is already minified by al_folio_core's Tailwind build, and `main.css` is compiled by Sass with `style: compressed`. Re-minifying them with `cssminify2` adds nothing (it actually makes `tailwind.css` ~315 bytes **larger**) and only introduces this corruption. So we disable redundant CSS minification, mirroring the existing `compress_javascript: false` (terser handles JS).

Verified end-to-end:
- The gem source `tailwind.css` has 82 intact `var(--spacing)`; `cssminify2` corrupts all 82.
- jekyll-minifier (`lib/jekyll-minifier.rb:1061`): `return output_file(path, content) unless config.compress_css?` — with `compress_css: false`, `.css` files are written verbatim.
- A real `JEKYLL_ENV=production` build now emits `tailwind.css` with 82 intact `var(--spacing)`, 0 corrupted, and
`.fixed-top{...;position:fixed}` intact.
- PurgeCSS (the next deploy stage) preserves `calc(var(--spacing)*0)` unchanged.

## Changes

1. **`_config.yml` — `jekyll-minifier.compress_css: false`** (the navbar fix).
2. **`test/integration_css_minify.sh` + `unit-tests.yml`** — a regression test that builds in **production mode** (the mode that exposes this bug class) and asserts no `var( - - )` corruption, intact `var(--spacing)`, a valid `.fixed-top`, and a non-empty `main.css`. Passes with the fix; fails without it (83 corruptions). Closes the CI blind spot that let this ship.
3. **`_config.yml` — drop dead `jekyll-minifier` exclude** `assets/js/search/*.js`. That is a v0 path; in v1 the search runtime ships under `assets/al_search/js/...`, so the glob matched nothing.
4. **`purgecss.config.js` — safelist `medium-zoom-overlay` / `medium-zoom-image--opened`.** These classes are injected at runtime, so they never appear in the static HTML PurgeCSS scans; their `z-index:999` overlay rule was being purged on the deployed site, letting the scroll-progress bar / ToC bleed through a zoomed image. Verified: the rule survives purge with the safelist and is dropped without it.

## Broader audit — plugin fixes (released + pinned here)

I audited for the same bug class (regressions invisible to dev-mode builds / leftovers from the v1 jQuery removal). The confirmed plugin-owned issues were each fixed in their own repo, merged after green CI, released to RubyGems, and pinned in this PR's `Gemfile`:

- **al_folio_core 1.0.10** ([#18](https://github.com/al-org-dev/al-folio-core/pull/18)) — `main.css` cache-bust was permanently the empty-string MD5 (`bust_css_cache` globbed a non-existent `assets/_sass`) → stale CSS after deploys; `bib.liquid` "N more authors" used `$(this)` → threw and never expanded; `figure.liquid` `onerror` used `$()` → dead broken-image fallback.
- **al_charts 1.0.1** ([#7](https://github.com/al-org-dev/al-charts/pull/7)) — `chartjs-setup.js` was jQuery → `chartjs` charts threw `$ is not defined` and never rendered.
- **al_folio_distill 1.0.2** ([#2](https://github.com/al-org-dev/al-folio-distill/pull/2)) — `overrides.js` top-level `$(window).on("load")` → distill footnote/citation theming never applied + console error.

Verified end-to-end with a production build after the pin bumps: `main.css` now cache-busts to a real hash (`9278fad1…`, not `d41d8cd9…`), zero jQuery `$(` in the built HTML, and the Tailwind spacing utilities / `.fixed-top` navbar are intact.

Also noted (not fixed here): the `visual-regression` workflow only renders in dev mode, so it can't catch production-only CSS regressions — `test/integration_css_minify.sh` is the immediate guard; a production screenshot leg would be a fuller backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

## Summary

Describe what changed and why.

## Ownership Routing

- [ ] I confirmed this PR targets the correct repo based on `docs/BOUNDARIES.md`.
- [ ] This PR only changes starter-owned scope (`al-folio`) **or** I am porting a routed change and linked the owning repo issue/PR.

Owning repo (if not starter): <!-- e.g., al-org-dev/al-folio-core -->
Related issue/PR: <!-- link -->

## Plugin Ecosystem (if applicable)

- [ ] Not applicable
- [ ] This PR proposes a plugin for **featured-only** listing.
- [ ] This PR proposes a plugin for **bundled** starter inclusion.

If plugin-related, provide:

- Plugin repo URL:
- Gem name:
- Jekyll plugin id:
- Compatibility (`al_folio_min`/`al_folio_max`):
- Demo page/post path:
- Maintainer contact:

## Starter Wiring Changes

- [ ] Not applicable
- [ ] Updated `Gemfile` dependency wiring.
- [ ] Updated `_config.yml` plugin activation/config.
- [ ] Updated `_data/featured_plugins.yml` metadata.

## Validation

- [ ] `npm ci`
- [ ] `bundle exec jekyll build`
- [ ] `npm run lint:prettier`
- [ ] `npm run lint:style-contract`
- [ ] Integration tests (`test/integration_*.sh`) as needed
- [ ] Visual tests (`npm run test:visual`) as needed

## Notes

Compatibility, migration implications, and follow-ups:
